### PR TITLE
[fix] 집들이 생성 사용자 연관관계 매핑

### DIFF
--- a/src/main/java/com/prgrms/ohouse/domain/community/application/HousewarmingPostService.java
+++ b/src/main/java/com/prgrms/ohouse/domain/community/application/HousewarmingPostService.java
@@ -9,7 +9,7 @@ import com.prgrms.ohouse.domain.community.application.command.CreateHousewarming
 
 public interface HousewarmingPostService {
 	@Transactional
-	Long createPost(CreateHousewarmingPostCommand command, List<MultipartFile> images);
+	Long createPost(Long userId, CreateHousewarmingPostCommand command, List<MultipartFile> images);
 
 	//
 	// 삭제

--- a/src/main/java/com/prgrms/ohouse/domain/community/application/impl/HousewarmingPostServiceImpl.java
+++ b/src/main/java/com/prgrms/ohouse/domain/community/application/impl/HousewarmingPostServiceImpl.java
@@ -8,16 +8,17 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import com.prgrms.ohouse.domain.common.file.FileManager;
+import com.prgrms.ohouse.domain.community.application.HousewarmingPostService;
 import com.prgrms.ohouse.domain.community.application.UnauthorizedContentAccessException;
 import com.prgrms.ohouse.domain.community.application.command.CreateHousewarmingPostCommand;
 import com.prgrms.ohouse.domain.community.model.housewarming.HousewarmingPost;
 import com.prgrms.ohouse.domain.community.model.housewarming.HousewarmingPostRepository;
+import com.prgrms.ohouse.domain.user.model.User;
 import com.prgrms.ohouse.domain.user.model.UserRepository;
 
 @Service
 @Transactional(readOnly = true)
-public class HousewarmingPostServiceImpl implements
-	com.prgrms.ohouse.domain.community.application.HousewarmingPostService {
+public class HousewarmingPostServiceImpl implements HousewarmingPostService {
 
 	private final HousewarmingPostRepository housewarmingPostRepository;
 	private final FileManager fileManager;
@@ -32,11 +33,14 @@ public class HousewarmingPostServiceImpl implements
 
 	@Override
 	@Transactional
-	public Long createPost(CreateHousewarmingPostCommand command, List<MultipartFile> images) {
-		HousewarmingPost post = housewarmingPostRepository.save(command.toPost());
+	public Long createPost(Long userId, CreateHousewarmingPostCommand command, List<MultipartFile> images) {
+		User user = userRepository.findById(userId).orElseThrow();
+		HousewarmingPost post = command.toPost();
+		post.assignUser(user);
+		post = housewarmingPostRepository.save(post);
 		post.validateContent(images.size());
 		fileManager.store(images, post);
-		// TODO: 사용자 id 받은 뒤에 post와 연관 관계 맺기
+		housewarmingPostRepository.save(post);
 		return post.getId();
 	}
 

--- a/src/main/java/com/prgrms/ohouse/domain/community/model/housewarming/HousewarmingPost.java
+++ b/src/main/java/com/prgrms/ohouse/domain/community/model/housewarming/HousewarmingPost.java
@@ -132,5 +132,9 @@ public class HousewarmingPost implements ImageAttachable {
 		images.add(image);
 		return image;
 	}
+
+	public void assignUser(User user) {
+		this.user = user;
+	}
 }
 

--- a/src/main/java/com/prgrms/ohouse/web/community/housewarming/api/HousewarmingPostController.java
+++ b/src/main/java/com/prgrms/ohouse/web/community/housewarming/api/HousewarmingPostController.java
@@ -44,8 +44,8 @@ public class HousewarmingPostController {
 	public ResponseEntity<String> handleCreatePostRequest(
 		@RequestPart("payload") @Valid HousewarmingPostCreateRequest payload,
 		@RequestPart("image") List<MultipartFile> images) {
-
-		Long postId = postService.createPost(payload.toCommand(), images);
+		Long userId = AuthUtils.getAuthUser().getId();
+		Long postId = postService.createPost(userId, payload.toCommand(), images);
 
 		return ResponseEntity.created(URI.create(host + "api/v0/hwpost/" + postId)).body("post creation success");
 	}

--- a/src/test/java/com/prgrms/ohouse/domain/community/application/HousewarmingPostServiceImplTest.java
+++ b/src/test/java/com/prgrms/ohouse/domain/community/application/HousewarmingPostServiceImplTest.java
@@ -40,6 +40,7 @@ class HousewarmingPostServiceImplTest {
 		// TODO: 선택 필드 테스트 케이스
 
 		// Given
+		var user = fixtureProvider.insertGuestUser("guest");
 		var command = CreateHousewarmingPostCommand.builder()
 			.title("test1")
 			.content("test1content")
@@ -52,11 +53,12 @@ class HousewarmingPostServiceImplTest {
 			.build();
 
 		// When
-		Long postId = housewarmingPostServiceImpl.createPost(command, Collections.emptyList());
+		Long postId = housewarmingPostServiceImpl.createPost(user.getId(), command, Collections.emptyList());
 
 		// Then
 		var createdPost = housewarmingPostRepository.findById(postId);
 		assertThat(createdPost).isNotEmpty();
+		assertThat(createdPost.get().getUser().getId()).isEqualTo(user.getId());
 		assertThat(createdPost.get()).extracting("title").isEqualTo("test1");
 		assertThat(createdPost.get().getBudget().getTotal()).isEqualTo(250L);
 		assertThat(createdPost.get().getWorkMetadata().getWorkerType()).isEqualTo(WorkerType.SELF);

--- a/src/test/java/com/prgrms/ohouse/infrastructure/TestDataProvider.java
+++ b/src/test/java/com/prgrms/ohouse/infrastructure/TestDataProvider.java
@@ -34,6 +34,7 @@ import com.prgrms.ohouse.domain.user.model.UserRepository;
 @Component
 @Transactional
 public class TestDataProvider {
+	public static final String GUEST_TOKEN = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJndWVzdEBnbWFpbC5jb20iLCJyb2xlcyI6W3siYXV0aG9yaXR5IjoiUk9MRV9VU0VSIn1dLCJpYXQiOjE2NTYzMTU3NDQsImV4cCI6MTY1ODA0Mzc0NH0.SN55dE55PSha8BpAFP_J6zd113Tnnk2eDF1Ni2Gd53U";
 	@Autowired
 	private UserRepository userRepository;
 	@Autowired

--- a/src/test/java/com/prgrms/ohouse/web/api/HousewarmingPostControllerTest.java
+++ b/src/test/java/com/prgrms/ohouse/web/api/HousewarmingPostControllerTest.java
@@ -17,6 +17,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMultipartHttpServletRequestBuilder;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -43,9 +44,6 @@ class HousewarmingPostControllerTest {
 	@Value("${app.host}")
 	private String host;
 
-	@Value("${file.dir}")
-	private String fileDir;
-
 	@Test
 	@DisplayName("집들이 게시물 생성 요청을 애플리케이션에 전달한 뒤 생성된 게시물의 URI를 응답한다.")
 	void HousewarmingCrateRequest() throws Exception {
@@ -70,7 +68,9 @@ class HousewarmingPostControllerTest {
 				new MockMultipartFile("image", "fav.png", "image/png", "chunk1".getBytes()),
 				new MockMultipartFile("image", "fav2.png", "image/png", "chunk2".getBytes())
 			);
-		var multipartRequest = multipart(HW_URL);
+		fixtureProvider.insertGuestUser("guest");
+		MockMultipartHttpServletRequestBuilder multipartRequest = (MockMultipartHttpServletRequestBuilder)multipart(
+			HW_URL).header("Authorization", TestDataProvider.GUEST_TOKEN);
 		images.forEach(multipartRequest::file);
 		multipartRequest.file(payloadPart);
 		// When


### PR DESCRIPTION
집들이 생성을 할 때 존재하는 사용자 id를 받아서 repository를 조회한 후 연관관계를 맺는 방식으로 했는데, 하드코딩 된 느낌이 있어서 더 좋은 방식을 추천해주시면 반영해보겠습니다.
